### PR TITLE
lstring: add preferedlanguages, handle # keys correctly

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -153,7 +153,6 @@ const nullRef = ref();
 
     <h2>Multi Language Function</h2>
     <div class="d-flex flex-column gap-2 align-items-center">
-      <code>lstring("¡hola!"):</code> {{ lstring("¡hola!") }}
       <code>lstring(langValues):</code> {{ lstring(langValues) }}
       <code>lstring(langValues, 'es', 'fr', 'en'):</code> {{ lstring(langValues, 'es', 'fr', 'en') }}
       <code>lstring({ "#meta": "the meta!", "fr": "L'affaire" }):</code> {{ lstring({ "#meta": "the meta!", "fr": "L'affaire" }) }}

--- a/src/app.vue
+++ b/src/app.vue
@@ -153,19 +153,22 @@ const nullRef = ref();
 
     <h2>Multi Language Function</h2>
     <div class="d-flex flex-column gap-2 align-items-center">
+      <code>lstring("¡hola!"):</code> {{ lstring("¡hola!") }}
       <code>lstring(langValues):</code> {{ lstring(langValues) }}
-      <code>trim({ en: ' foo ', fr: 'bar', es: undefined, kl: '' }): </code> {{ trim({
-      en: ' foo ', fr: 'bar', es:
-      undefined, kl: ''
-      }) }}
+      <code>lstring(langValues, 'es', 'fr', 'en'):</code> {{ lstring(langValues, 'es', 'fr', 'en') }}
+      <code>lstring({ "#meta": "the meta!", "fr": "L'affaire" }):</code> {{ lstring({ "#meta": "the meta!", "fr": "L'affaire" }) }}
+      <code>lstring({ "#meta": "the meta!" }):</code> {{ lstring({ "#meta": "the meta!" }) }}
+      <code>trim({ en: ' foo ', fr: 'bar', es: undefined, kl: '' }): </code> {{ trim({ en: ' foo ', fr: 'bar', es: undefined, kl: '' }) }}
       <code>isNullOrEmpty({ en: 'nope' }): </code> {{ isNullOrEmpty({ en: 'nope' }) }}
       <code>isNullOrEmpty({ en: '', fr: 'non' }): </code> {{ isNullOrEmpty({ en: '', fr: 'non' }) }}
       <code>isNullOrEmpty({ en: ' ' }): </code> {{ isNullOrEmpty({ en: ' ' }) }}
       <code>isNullOrEmpty({}): </code> {{ isNullOrEmpty({}) }}
+      <code>isNullOrEmpty({ "#meta": "Meta stuff" }): </code> {{ isNullOrEmpty({ "#meta": "Meta stuff" }) }}
       <code>isNullOrEmpty(): </code> {{ isNullOrEmpty() }}
       <code>isNullOrWhiteSpace({}): </code> {{ isNullOrWhiteSpace({ en: '' }) }}
       <code>isNullOrWhiteSpace({ en: '' }): </code> {{ isNullOrWhiteSpace({ en: '' }) }}
       <code>isNullOrWhiteSpace({ en: ' ' }): </code> {{ isNullOrWhiteSpace({ en: ' ' }) }}
+      <code>isNullOrWhiteSpace({ en: ' ', "#meta": "ASDF" }): </code> {{ isNullOrWhiteSpace({ en: ' ', "#meta": "ASDF" }) }}
       <code>isNullOrWhiteSpace({ en: 'nope' }): </code> {{ isNullOrWhiteSpace({ en: 'nope' }) }}
     </div>
 

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -2,7 +2,7 @@ import { Locales } from "../data/un-languages";
 import type { Locale } from "../types/lstring";
 import type LString from "../types/lstring";
 
-export default function (ltext?: LString | { [locale: string]: string }, ...preferedLocales: Locale[]): string {
+export default function (ltext: LString | { [locale: string]: string }, ...preferedLocales: Locale[]): string {
   if (!ltext) return "";
 
   const cleaned = cleanLString(ltext) as LString;
@@ -29,17 +29,17 @@ export default function (ltext?: LString | { [locale: string]: string }, ...pref
   return text;
 }
 
-export function trim(ltext?: LString | { [locale: string]: string }) {
+export function trim(ltext: LString | { [locale: string]: string }) {
   if (!ltext) return ltext;
 
   return Object.entries(ltext).reduce((ret, [k, v]) => ({ ...ret, [k]: v?.trim() }), {});
 }
 
-export function isNullOrEmpty(ltext?: LString | { [locale: string]: string }) {
+export function isNullOrEmpty(ltext: LString | { [locale: string]: string }) {
   return !ltext || !Object.values(cleanLString(ltext)).some(Boolean);
 }
 
-export function isNullOrWhiteSpace(ltext?: LString | { [locale: string]: string }) {
+export function isNullOrWhiteSpace(ltext: LString | { [locale: string]: string }) {
   return !ltext || !Object.values(trim(cleanLString(ltext))).some(Boolean);
 }
 
@@ -47,7 +47,7 @@ function isValidLocaleEntry([k, v]: any) {
   return k && !k.startsWith("#")
 }
 
-function cleanLString(ltext?: LString | { [locale: string]: string }): LString | { [locale: string]: string } {
+function cleanLString(ltext: LString | { [locale: string]: string }): LString | { [locale: string]: string } {
   if (!ltext) return {};
 
   return Object.entries(ltext)

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -13,7 +13,7 @@ export default function (ltext?: string | LString | { [locale: string]: string }
   const ltextLocales = Object.keys(cleanedLtext);
   const locale = preferedLocales.find((l) => ltextLocales.includes(l)) || "en"; // TODO default to i18n.locale instead ;
 
-  let text = cleanedLtext[locale] as string | undefined;
+  let text = cleanedLtext[locale] as string | null;
 
   if (!text) {
     const firstAvailableLocale = Locales.find((l) => !!cleanedLtext[l]);

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -48,7 +48,7 @@ function isValidLocaleEntry([k, v]: any) {
 }
 
 function cleanLString(ltext?: LString | { [locale: string]: string }): LString | { [locale: string]: string } {
-  if (!ltext) return ltext;
+  if (!ltext) return {};
 
   return Object.entries(ltext)
     .filter(isValidLocaleEntry)

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -2,10 +2,8 @@ import { Locales } from "../data/un-languages";
 import type { Locale } from "../types/lstring";
 import type LString from "../types/lstring";
 
-export default function (ltext?: string | LString | { [locale: string]: string }, ...preferedLocales: Locale[]): string {
+export default function (ltext?: LString | { [locale: string]: string }, ...preferedLocales: Locale[]): string {
   if (!ltext) return "";
-
-  if (typeof (ltext) === 'string') return ltext;
 
   const cleaned = cleanLString(ltext) as LString;
   const ltextLocales = Object.keys(cleaned);
@@ -31,19 +29,17 @@ export default function (ltext?: string | LString | { [locale: string]: string }
   return text;
 }
 
-export function trim(ltext?: string | LString | { [locale: string]: string }) {
+export function trim(ltext?: LString | { [locale: string]: string }) {
   if (!ltext) return ltext;
-
-  if (typeof (ltext) === 'string') return ltext.trim();
 
   return Object.entries(ltext).reduce((ret, [k, v]) => ({ ...ret, [k]: v?.trim() }), {});
 }
 
-export function isNullOrEmpty(ltext?: string | LString | { [locale: string]: string }) {
+export function isNullOrEmpty(ltext?: LString | { [locale: string]: string }) {
   return !ltext || !Object.values(cleanLString(ltext)).some(Boolean);
 }
 
-export function isNullOrWhiteSpace(ltext?: string | LString | { [locale: string]: string }) {
+export function isNullOrWhiteSpace(ltext?: LString | { [locale: string]: string }) {
   return !ltext || !Object.values(trim(cleanLString(ltext))).some(Boolean);
 }
 
@@ -51,8 +47,8 @@ function isValidLocaleEntry([k, v]: any) {
   return k && !k.startsWith("#")
 }
 
-function cleanLString(ltext?: string | LString | { [locale: string]: string }): string | LString | { [locale: string]: string } | null | undefined {
-  if (!ltext || typeof (ltext) === 'string') return ltext;
+function cleanLString(ltext?: LString | { [locale: string]: string }): LString | { [locale: string]: string } {
+  if (!ltext) return ltext;
 
   return Object.entries(ltext)
     .filter(isValidLocaleEntry)

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -7,23 +7,21 @@ export default function (ltext?: string | LString | { [locale: string]: string }
 
   if (typeof (ltext) === 'string') return ltext;
 
-  const cleanedLtext: LString | { [locale: string]: string } = Object.entries(ltext)
-    .filter(isValidLocaleEntry)
-    .reduce((o, [k, v]) => ({ ...o, [k]: v }), {});
-  const ltextLocales = Object.keys(cleanedLtext);
+  const cleaned = cleanLString(ltext) as LString;
+  const ltextLocales = Object.keys(cleaned);
   const locale = preferedLocales.find((l) => ltextLocales.includes(l)) || "en";
 
-  let text = cleanedLtext[locale] as string | null;
+  let text = cleaned[locale] as string | null;
 
   if (!text) {
-    const firstAvailableLocale = Locales.find((l) => !!cleanedLtext[l]);
+    const firstAvailableLocale = Locales.find((l) => !!cleaned[l]);
 
-    if (firstAvailableLocale) text = cleanedLtext[firstAvailableLocale];
+    if (firstAvailableLocale) text = cleaned[firstAvailableLocale];
   }
 
   if (!text) {
     // cannot find any of the un locales..... return first text value
-    text = Object.values(cleanedLtext)
+    text = Object.values(cleaned)
       .filter(o => typeof (o) === 'string')
       .filter(o => !!o)[0];
   }
@@ -42,17 +40,21 @@ export function trim(ltext?: string | LString | { [locale: string]: string }) {
 }
 
 export function isNullOrEmpty(ltext?: string | LString | { [locale: string]: string }) {
-  return !ltext || !Object.entries(ltext)
-    .filter(isValidLocaleEntry)
-    .some(([k, v]) => !!v);
+  return !ltext || !Object.values(cleanLString(ltext)).some(Boolean);
 }
 
 export function isNullOrWhiteSpace(ltext?: string | LString | { [locale: string]: string }) {
-  return !ltext || !Object.entries(trim(ltext))
-    .filter(isValidLocaleEntry)
-    .some(([k, v]) => !!v);
+  return !ltext || !Object.values(trim(cleanLString(ltext))).some(Boolean);
 }
 
 function isValidLocaleEntry([k, v]: any) {
   return k && !k.startsWith("#")
+}
+
+function cleanLString(ltext?: string | LString | { [locale: string]: string }): string | LString | { [locale: string]: string } | null | undefined {
+  if (!ltext || typeof (ltext) === 'string') return ltext;
+
+  return Object.entries(ltext)
+    .filter(isValidLocaleEntry)
+    .reduce((o, [k, v]) => ({ ...o, [k]: v }), {});
 }

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -11,7 +11,7 @@ export default function (ltext?: string | LString | { [locale: string]: string }
     .filter(isValidLocaleEntry)
     .reduce((o, [k, v]) => ({ ...o, [k]: v }), {});
   const ltextLocales = Object.keys(cleanedLtext);
-  const locale = preferedLocales.find((l) => ltextLocales.includes(l)) || "en"; // TODO default to i18n.locale instead ;
+  const locale = preferedLocales.find((l) => ltextLocales.includes(l)) || "en";
 
   let text = cleanedLtext[locale] as string | null;
 

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -2,24 +2,28 @@ import { Locales } from "../data/un-languages";
 import type { Locale } from "../types/lstring";
 import type LString from "../types/lstring";
 
-export default function (ltext: string | LString | { [locale: string]: string } | null | undefined, preferedLocale?: Locale): string {
+export default function (ltext?: string | LString | { [locale: string]: string }, ...preferedLocales: Locale[]): string {
   if (!ltext) return "";
 
   if (typeof (ltext) === 'string') return ltext;
 
-  const locale = preferedLocale || "en"; // TODO default to i18n.locale instead ;
+  const cleanedLtext: LString | { [locale: string]: string } = Object.entries(ltext)
+    .filter(isValidLocaleEntry)
+    .reduce((o, [k, v]) => ({ ...o, [k]: v }), {});
+  const ltextLocales = Object.keys(cleanedLtext);
+  const locale = preferedLocales.find((l) => ltextLocales.includes(l)) || "en"; // TODO default to i18n.locale instead ;
 
-  let text = ltext[locale] as string | undefined;
+  let text = cleanedLtext[locale] as string | undefined;
 
   if (!text) {
-    const firstAvailableLocale = Locales.find((l) => !!ltext[l]);
+    const firstAvailableLocale = Locales.find((l) => !!cleanedLtext[l]);
 
-    if (firstAvailableLocale) text = ltext[firstAvailableLocale];
+    if (firstAvailableLocale) text = cleanedLtext[firstAvailableLocale];
   }
 
   if (!text) {
     // cannot find any of the un locales..... return first text value
-    text = Object.values(ltext)
+    text = Object.values(cleanedLtext)
       .filter(o => typeof (o) === 'string')
       .filter(o => !!o)[0];
   }
@@ -29,14 +33,26 @@ export default function (ltext: string | LString | { [locale: string]: string } 
   return text;
 }
 
-export function trim(ltext: LString) {
+export function trim(ltext?: string | LString | { [locale: string]: string }) {
+  if (!ltext) return ltext;
+
+  if (typeof (ltext) === 'string') return ltext.trim();
+
   return Object.entries(ltext).reduce((ret, [k, v]) => ({ ...ret, [k]: v?.trim() }), {});
 }
 
-export function isNullOrEmpty(ltext?: LString) {
-  return !ltext || !Object.values(ltext).some(Boolean);
+export function isNullOrEmpty(ltext?: string | LString | { [locale: string]: string }) {
+  return !ltext || !Object.entries(ltext)
+    .filter(isValidLocaleEntry)
+    .some(([k, v]) => !!v);
 }
 
-export function isNullOrWhiteSpace(ltext?: LString) {
-  return !ltext || !Object.values(trim(ltext)).some(Boolean);
+export function isNullOrWhiteSpace(ltext?: string | LString | { [locale: string]: string }) {
+  return !ltext || !Object.entries(trim(ltext))
+    .filter(isValidLocaleEntry)
+    .some(([k, v]) => !!v);
+}
+
+function isValidLocaleEntry([k, v]: any) {
+  return k && !k.startsWith("#")
 }


### PR DESCRIPTION
Add to lstring:
- lstring(ltext, "en", "es", etc)
- handle # keys correctly

Per the (sort of) tests in src/App.vue:
- `lstring({ en: 'English value', fr: 'La valeure française'}, 'es', 'fr', 'en'):` La valeure française
- `lstring({ "#meta": "the meta!", "fr": "L'affaire" }):` L'affaire
- `lstring({ "#meta": "the meta!" }):` undefined
