### PR TITLE
Build errors in dependent projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "vite build && vue-tsc -p tsconfig.json",
     "prepare": "vite build && vue-tsc -p tsconfig.json",
     "prepack": "vite build && vue-tsc -p tsconfig.json",
-    "clean": "rm -rf ./dist ./dist-types"
+    "clean-reinstall": "rm -rf node_modules dist dist-types && yarn install"
   },
   "peerDependencies": {
     "@coreui/coreui": "^5.2.0",

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -35,11 +35,11 @@ export function trim(ltext: LString | { [locale: string]: string }) {
   return Object.entries(ltext).reduce((ret, [k, v]) => ({ ...ret, [k]: v?.trim() }), {});
 }
 
-export function isNullOrEmpty(ltext: LString | { [locale: string]: string }) {
+export function isNullOrEmpty(ltext?: LString | { [locale: string]: string }) {
   return !ltext || !Object.values(cleanLString(ltext)).some(Boolean);
 }
 
-export function isNullOrWhiteSpace(ltext: LString | { [locale: string]: string }) {
+export function isNullOrWhiteSpace(ltext?: LString | { [locale: string]: string }) {
   return !ltext || !Object.values(trim(cleanLString(ltext))).some(Boolean);
 }
 

--- a/src/utils/lstring.ts
+++ b/src/utils/lstring.ts
@@ -9,7 +9,7 @@ export default function (ltext: LString | { [locale: string]: string }, ...prefe
   const ltextLocales = Object.keys(cleaned);
   const locale = preferedLocales.find((l) => ltextLocales.includes(l)) || "en";
 
-  let text = cleaned[locale] as string | null;
+  let text = cleaned[locale] as string | null | undefined;
 
   if (!text) {
     const firstAvailableLocale = Locales.find((l) => !!cleaned[l]);


### PR DESCRIPTION
Typescript definitions in the lstring utility produced build errors when building from a dependent (strata in this specific case) that was cleaned and had its yarn.lock file deleted. 

TS errors observed in strata:
```
src/app.vue:166:41 - error TS2554: Expected 1 arguments, but got 0.

166       <code>isNullOrEmpty(): </code> {{ isNullOrEmpty() }}
                                            ~~~~~~~~~~~~~

  src/utils/lstring.ts:38:31
    38 export function isNullOrEmpty(ltext: LString | { [locale: string]: string }) {
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'ltext' was not provided.

src/utils/lstring.ts:17:31 - error TS2322: Type 'string | undefined' is not assignable to type 'string | null'.
  Type 'undefined' is not assignable to type 'string | null'.

17     if (firstAvailableLocale) text = cleaned[firstAvailableLocale];
                                 ~~~~
```

It's unclear why those error we not observed before but those errors (and corresponding simple fixes) seem valid to me.

I also added the yarn script `clean-reinstall` to align with other SCBD projects.