### PR TITLE
feat: support disabled controls

### DIFF
--- a/examples/vue-app/src/app.vue
+++ b/examples/vue-app/src/app.vue
@@ -49,6 +49,13 @@ const timezone = "America/Montreal";
         label="Multi Select"
         :multiple="true"
       />
+      <ScbdSelect
+        :options="options"
+        v-model="selectedOption"
+        placeholder="Disabled select"
+        label="Single Select (disabled)"
+        disabled
+      />
     </div>
 
     <h2>Multi Language Input</h2>
@@ -72,6 +79,11 @@ const timezone = "America/Montreal";
         { locale: 'kl', name: 'Klingon', direction: 'ltr' },
       ]"
     />
+    <ScbdMultiLanguageInput
+      label="Multi Language Input (disabled)"
+      v-model="langValues"
+      disabled
+    />
 
     <h2>Multi Language Function</h2>
     <div class="d-flex gap-2 align-items-center">
@@ -83,21 +95,45 @@ const timezone = "America/Montreal";
       label="Date"
       v-model="date"
     ></ScbdDateInput>
+    <ScbdDateInput
+      label="Date (disabled)"
+      v-model="date"
+      disabled
+    />
     <ScbdDateRangeInput
       label="Date"
       v-model:start-date="date"
       v-model:end-date="date"
+    />
+    <ScbdDateRangeInput
+      label="Date (disabled)"
+      v-model:start-date="date"
+      v-model:end-date="date"
+      disabled
     />
     <ScbdDatetimeInput
       label="Datetime"
       v-model="datetime"
       :timezone="timezone"
     />
+    <ScbdDatetimeInput
+      label="Datetime (disabled)"
+      v-model="datetime"
+      :timezone="timezone"
+      disabled
+    />
     <ScbdDatetimeRangeInput
       label="Datetime"
       v-model:start-date="datetime"
       v-model:end-date="datetime"
       :timezone="timezone"
+    />
+    <ScbdDatetimeRangeInput
+      label="Datetime (disabled)"
+      v-model:start-date="datetime"
+      v-model:end-date="datetime"
+      :timezone="timezone"
+      disabled
     />
   </div>
 </template>

--- a/src/app.vue
+++ b/src/app.vue
@@ -150,6 +150,11 @@ const nullRef = ref();
       :languages="customLangs"
       :placeholders="customLangPlaceholders"
     />
+    <MultiLanguageInput
+      label="Multi Language Input (disabled)"
+      v-model="langValues"
+      disabled
+    />
 
     <h2>Multi Language Function</h2>
     <div class="d-flex flex-column gap-2 align-items-center">

--- a/src/app.vue
+++ b/src/app.vue
@@ -95,6 +95,13 @@ const nullRef = ref();
           {{ values.length }} foos
         </template>
       </Select>
+      <Select
+        :options="options"
+        v-model="selectedOption"
+        placeholder="Disabled select"
+        label="Single Select (disabled)"
+        disabled
+      />
     </div>
 
     <h2>Multi Language Input</h2>
@@ -182,6 +189,11 @@ const nullRef = ref();
       v-model="date"
     />
     <DateInput
+      label="Date (disabled)"
+      v-model="date"
+      disabled
+    />
+    <DateInput
       label="Date"
       v-model="date"
       :valid="true"
@@ -201,10 +213,22 @@ const nullRef = ref();
       v-model:start-date="date"
       v-model:end-date="date"
     />
+    <DateRangeInput
+      label="Date (disabled)"
+      v-model:start-date="date"
+      v-model:end-date="date"
+      disabled
+    />
     <DatetimeInput
       label="Datetime"
       v-model="datetime"
       :timezone="timezone"
+    />
+    <DatetimeInput
+      label="Datetime (disabled)"
+      v-model="datetime"
+      :timezone="timezone"
+      disabled
     />
     <DatetimeInput
       label="Datetime"
@@ -234,6 +258,13 @@ const nullRef = ref();
       v-model:start-date="datetime"
       v-model:end-date="datetime"
       :timezone="timezone"
+    />
+    <DatetimeRangeInput
+      label="Datetime (disabled)"
+      v-model:start-date="datetime"
+      v-model:end-date="datetime"
+      :timezone="timezone"
+      disabled
     />
 
   </div>

--- a/src/components/multi-language-input.vue
+++ b/src/components/multi-language-input.vue
@@ -112,6 +112,8 @@ const someInvalid = computed(() => typeof (props.invalid) === "boolean"
   : props.invalid && Object.values(props.invalid).some((v) => v === true))
 
 const modelUpdated = (locale: Locale, value: string) => {
+  if (props.disabled) return;
+
   if (modifiers.trim) {
     value = value.trim();
   }

--- a/src/components/multi-language-input.vue
+++ b/src/components/multi-language-input.vue
@@ -40,7 +40,7 @@
             <CInputGroupText
               v-if="index == 0"
               class="expand"
-              @click="!disabled && (expanded = !expanded)"
+              @click="expanded = !expanded"
             >
               <CIcon
                 v-if="expanded"

--- a/src/components/multi-language-input.vue
+++ b/src/components/multi-language-input.vue
@@ -24,6 +24,7 @@
               @update:modelValue="modelUpdated(lang.locale, $event)"
               :valid="isValid[lang.locale] || !expanded && someValid"
               :invalid="isInvalid[lang.locale] || !expanded && someInvalid"
+              :disabled="disabled"
             />
             <CFormInput
               v-else
@@ -34,11 +35,12 @@
               @update:modelValue="modelUpdated(lang.locale, $event)"
               :valid="isValid[lang.locale] || !expanded && someValid"
               :invalid="isInvalid[lang.locale] || !expanded && someInvalid"
+              :disabled="disabled"
             />
             <CInputGroupText
               v-if="index == 0"
               class="expand"
-              @click="expanded = !expanded"
+              @click="!disabled && (expanded = !expanded)"
             >
               <CIcon
                 v-if="expanded"
@@ -76,6 +78,7 @@ const props = withDefaults(defineProps<{
   label?: string,
   multiple?: boolean,
   rows?: number,
+  disabled?: boolean,
   valid?: boolean | { [Locale: string]: boolean },
   invalid?: boolean | { [Locale: string]: boolean },
   feedbackValid?: string,

--- a/src/components/select.vue
+++ b/src/components/select.vue
@@ -48,15 +48,15 @@
           <slot
             name="tag"
             :option="option"
-            :remove="remove"
+            :remove="disabled ? () => {} : remove"
           >
             <span>{{ option.label }}</span>
             <span style="padding: 6px">
               <i
                 aria-hidden="true"
-                tabindex="1"
+                :tabindex="disabled ? -1 : 1"
                 class="multiselect__tag-icon"
-                @click="remove(option)"
+                @click="!disabled && remove(option)"
               />
             </span>
           </slot>
@@ -65,7 +65,7 @@
 
       <template #clear>
         <div
-          v-if="selectedOptions.length"
+          v-if="selectedOptions.length && !disabled"
           @mousedown.prevent.stop="selectedOptions = []"
         >
           <div class="multiselect__clear">

--- a/tests/components/date-input.test.ts
+++ b/tests/components/date-input.test.ts
@@ -27,4 +27,16 @@ describe('DateInput', () => {
 
     expect(modelValue).toBe('2025-06-15')
   })
+
+  it('disables the date input when disabled', async () => {
+    render(DateInput, {
+      props: {
+        label: 'Date',
+        modelValue: '2000-01-01',
+        disabled: true,
+      },
+    })
+
+    await expect.element(page.getByPlaceholder('Select date')).toBeDisabled()
+  })
 })

--- a/tests/components/date-range-input.test.ts
+++ b/tests/components/date-range-input.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import DateRangeInput from '../../src/components/date-range-input.vue'
+
+describe('DateRangeInput', () => {
+  it('disables both date inputs when disabled', async () => {
+    render(DateRangeInput, {
+      props: {
+        label: 'Publication',
+        startDate: '2000-01-01',
+        endDate: '2000-01-02',
+        disabled: true,
+      },
+    })
+
+    const inputs = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="date"]'))
+    expect(inputs).toHaveLength(2)
+    expect(inputs.every((input) => input.disabled)).toBe(true)
+  })
+})

--- a/tests/components/datetime-input.test.ts
+++ b/tests/components/datetime-input.test.ts
@@ -1,0 +1,19 @@
+import { page } from '@vitest/browser/context'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import DatetimeInput from '../../src/components/datetime-input.vue'
+
+describe('DatetimeInput', () => {
+  it('disables the datetime input when disabled', async () => {
+    render(DatetimeInput, {
+      props: {
+        label: 'Meeting',
+        modelValue: '2000-01-01T12:00:00.000Z',
+        timezone: 'America/Montreal',
+        disabled: true,
+      },
+    })
+
+    await expect.element(page.getByPlaceholder('Select date and time')).toBeDisabled()
+  })
+})

--- a/tests/components/datetime-range-input.test.ts
+++ b/tests/components/datetime-range-input.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import DatetimeRangeInput from '../../src/components/datetime-range-input.vue'
+
+describe('DatetimeRangeInput', () => {
+  it('disables both datetime inputs when disabled', async () => {
+    render(DatetimeRangeInput, {
+      props: {
+        label: 'Meeting',
+        startDate: '2000-01-01T12:00:00.000Z',
+        endDate: '2000-01-01T13:00:00.000Z',
+        timezone: 'America/Montreal',
+        disabled: true,
+      },
+    })
+
+    const inputs = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="datetime-local"]'))
+    expect(inputs).toHaveLength(2)
+    expect(inputs.every((input) => input.disabled)).toBe(true)
+  })
+})

--- a/tests/components/multi-language-input.test.ts
+++ b/tests/components/multi-language-input.test.ts
@@ -27,7 +27,7 @@ describe('MultiLanguageInput', () => {
     expect(modelValue).toEqual({ en: 'Hello' })
   })
 
-  it('disables every language input and the expand toggle when disabled', async () => {
+  it('disables every language input when disabled', async () => {
     render(MultiLanguageInput, {
       global,
       props: {
@@ -40,7 +40,7 @@ describe('MultiLanguageInput', () => {
     await expect.element(input).toBeDisabled()
   })
 
-  it('does not expand to reveal other languages when disabled', async () => {
+  it('can expand and collapse while disabled', async () => {
     render(MultiLanguageInput, {
       global,
       props: {
@@ -50,6 +50,10 @@ describe('MultiLanguageInput', () => {
     })
 
     const expandToggle = document.querySelector('.multi-language-input .expand') as HTMLElement
+    expandToggle.click()
+
+    await expect.element(page.getByPlaceholder('Español')).toBeDisabled()
+
     expandToggle.click()
 
     await expect.element(page.getByPlaceholder('Español')).not.toBeInTheDocument()

--- a/tests/components/multi-language-input.test.ts
+++ b/tests/components/multi-language-input.test.ts
@@ -1,0 +1,57 @@
+import { page } from '@vitest/browser/context'
+import * as icons from '@coreui/icons'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import MultiLanguageInput from '../../src/components/multi-language-input.vue'
+
+const global = { provide: { icons } }
+
+describe('MultiLanguageInput', () => {
+  it('updates its model when the user types in a language input', async () => {
+    let modelValue: Record<string, string> | undefined = undefined
+
+    render(MultiLanguageInput, {
+      global,
+      props: {
+        label: 'Name',
+        modelValue,
+        'onUpdate:modelValue': (value: Record<string, string>) => {
+          modelValue = value
+        },
+      },
+    })
+
+    const input = page.getByPlaceholder('English')
+    await input.fill('Hello')
+
+    expect(modelValue).toEqual({ en: 'Hello' })
+  })
+
+  it('disables every language input and the expand toggle when disabled', async () => {
+    render(MultiLanguageInput, {
+      global,
+      props: {
+        label: 'Name',
+        disabled: true,
+      },
+    })
+
+    const input = page.getByPlaceholder('English')
+    await expect.element(input).toBeDisabled()
+  })
+
+  it('does not expand to reveal other languages when disabled', async () => {
+    render(MultiLanguageInput, {
+      global,
+      props: {
+        label: 'Name',
+        disabled: true,
+      },
+    })
+
+    const expandToggle = document.querySelector('.multi-language-input .expand') as HTMLElement
+    expandToggle.click()
+
+    await expect.element(page.getByPlaceholder('Español')).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/select.test.ts
+++ b/tests/components/select.test.ts
@@ -1,0 +1,27 @@
+import { page } from '@vitest/browser/context'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import Select from '../../src/components/select.vue'
+
+const options = [
+  { label: 'One', value: 'one' },
+  { label: 'Two', value: 'two' },
+]
+
+describe('Select', () => {
+  it('disables the select and its selection actions when disabled', async () => {
+    render(Select, {
+      props: {
+        label: 'Choice',
+        modelValue: ['one'],
+        options,
+        multiple: true,
+        disabled: true,
+      },
+    })
+
+    await expect.element(page.getByRole('textbox')).toBeDisabled()
+    await expect.element(page.getByText('×')).not.toBeInTheDocument()
+    expect(document.querySelector('.multiselect__tag-icon')?.getAttribute('tabindex')).toBe('-1')
+  })
+})

--- a/tests/setup/headed.ts
+++ b/tests/setup/headed.ts
@@ -1,0 +1,6 @@
+import { afterEach } from 'vitest'
+
+// Gives you a moment to see each test's final state before the next one starts.
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1500))
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,20 @@
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vitest/config'
 
+const headed = process.argv.includes('--browser.headless=false')
+
 export default defineConfig({
   plugins: [vue()],
   test: {
+    setupFiles: headed ? ['./tests/setup/headed.ts'] : [],
     browser: {
       enabled: true,
       headless: true,
       instances: [
-        { browser: 'chromium' },
+        {
+          browser: 'chromium',
+          ...headed && { providerOptions: { launch: { slowMo: 250 } } },
+        },
       ],
       provider: 'playwright',
     },


### PR DESCRIPTION
## Summary

- add disabled support and demos for select, date, date-range, datetime, datetime-range, and multi-language controls
- prevent disabled select clear/remove actions and disabled multi-language model updates
- cover disabled behavior with browser component tests
- add headed test configuration for interactive browser verification

## Implementation

All public interactive controls now expose and demonstrate a consistent disabled state in both the source playground and packaged example app. `FormInputWrapper` remains unchanged because it is structural rather than interactive.

## Testing

- `yarn test` — 9 tests passed across 6 files
- `yarn build` — passed
- `cd examples/vue-app && yarn build` — passed
- screenshots captured from the local source playground and visually verified for disabled styling, values, and range composition

## User-Facing Changes

Disabled select and multi-language controls:

![Disabled select and multi-language controls](https://gist.githubusercontent.com/desmat/0ab68aed8663171f7ec24d77e0eda3e6/raw/ff175421195a5f659e2ee9ec9459dcf5ed53a8e9/disabled-text-controls.svg)

Disabled date, date-range, datetime, and datetime-range controls:

![Disabled date and time controls](https://gist.githubusercontent.com/desmat/0ab68aed8663171f7ec24d77e0eda3e6/raw/86748c22ff7ec0031dca55dc82cde6b816fea4dd/disabled-date-controls.svg)

[Screenshot evidence gist](https://gist.github.com/desmat/0ab68aed8663171f7ec24d77e0eda3e6)
